### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,18 @@
 $ docker run --name gmusicproxy -v /PATH/TO/gmusicproxy.cfg:/etc/gmusicproxy.cfg \
     -p 80:80 digitallyseamless/gmusicproxy --config=/etc/gmusicproxy.cfg
 ```
+
+#### gmusicproxy.cfg
+
+In order for the above `docker run` command to work the following `gmusicproxy.cfg` is needed.
+
+```
+email = your-email-address@gmail.com
+password = secret-app-password
+device-id = some-random-uuid-or-your-mac-address
+host = localhost
+port = 80
+```
+
+Read more config options at [gmusicproxy.net](http://gmusicproxy.net/#gmusicproxy-google-play-music-proxy-usage-config-file).
+


### PR DESCRIPTION
The default port is 9999 and the default host is the ip address. If only the minimum config options, as stated in gmusicproxy.net, are used the docker container is unable to work.

With this config an accessible host is used in the generated .m3u files.
